### PR TITLE
Add opt out flag DISABLE_OPENCOLLECTIVE

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,8 @@ And in your `package.json` add:
 }
 ```
 
+## Disabling this message
+In some places (e.g. CI) you may want to disable this output. You can do this by setting the environment variable `DISABLE_OPENCOLLECTIVE=true`.
+
 Note: This is a lightweight alternative to the [opencollective-cli](https://github.com/opencollective/opencollective-cli) that offers a more complete postinstall message with the current balance and ASCII logo of the collective.
+

--- a/index.js
+++ b/index.js
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
+if (process.env.DISABLE_OPENCOLLECTIVE && process.env.DISABLE_OPENCOLLECTIVE !== '0' && process.env.DISABLE_OPENCOLLECTIVE.toLowerCase() !== 'false') {
+  return;
+}
 var pkg = require(require('path').resolve('./package.json'));
 if (pkg.collective) {
   console.log(`\u001b[96m\u001b[1mThank you for using ${pkg.name}!\u001b[96m\u001b[1m`);
   console.log(`\u001b[0m\u001b[96mIf you rely on this package, please consider supporting our open collective:\u001b[22m\u001b[39m`);
   console.log(`> \u001b[94m${pkg.collective.url}/donate\u001b[0m\n`);
 }
+


### PR DESCRIPTION
When the environment variable DISABLE_OPENCOLLECTIVE is set to any value other than 0 or false, this flag will let users opt out of the postinstall-cli. This is useful in places that need to parse output and CI.

Fixes: https://github.com/opencollective/opencollective-postinstall/issues/8, https://github.com/opencollective/opencollective-cli/issues/7#issuecomment-375459231