### PR TITLE
fix: only include necessary files when publishing package

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "type": "git",
     "url": "git+https://github.com/opencollective/opencollective-postinstall.git"
   },
+  "files": [
+    "index.js"
+  ],
   "bin": "index.js",
   "keywords": [
     "opencollective",


### PR DESCRIPTION
Currently `index.test.js` is shipped in the published package, which isn't needed, and so unnecessarily increases the package size.

When present, `npm` will only pack the files targeted by the `files` property, along with `CHANGELOG.md`, `README.md`, `package.json`, and `LICENSE` if present.